### PR TITLE
add archive file to todotxt-mode configuration

### DIFF
--- a/emacs.el
+++ b/emacs.el
@@ -330,7 +330,9 @@
 
 ;;; TodoTxt
 (setq todotxt-default-file (expand-file-name "~/Dropbox/todo/todo.txt"))
+(setq todotxt-default-archive-file (expand-file-name "~/Dropbox/todo/done.txt"))
 (add-to-list 'auto-mode-alist '("/todo.txt$" . todotxt-mode))
+(add-to-list 'auto-mode-alist '("/done.txt$" . todotxt-mode))
 
 (add-hook 'before-save-hook 'delete-trailing-whitespace)
 


### PR DESCRIPTION
By default the done.txt file is placed in ~/done.txt. I'd like it to be moved into dropbox, so it is shared across devices as the todo.txt file.
