### PR TITLE
bind q to quit-window in diff mode... again

### DIFF
--- a/emacs.el
+++ b/emacs.el
@@ -251,6 +251,9 @@
               "L" 'bookmark-bmenu-load
               )
 
+            (add-hook 'diff-mode-hook
+                      (lambda ()
+                        (define-key evil-normal-state-local-map "q" 'quit-window))
 
             (add-hook 'compilation-mode-hook
                       (lambda ()


### PR DESCRIPTION
For some reason this change was reverted in the PR you merged after wards... 

https://github.com/sunesimonsen/evil-config/commit/8b88d91971a070be6d1afd8bc8cc44c0d202c17d

I have no clue why that happened.